### PR TITLE
(maint) Update bolt process to use WorkingDir

### DIFF
--- a/posh-bolt/Private/Invoke-BoltInternal.ps1
+++ b/posh-bolt/Private/Invoke-BoltInternal.ps1
@@ -48,6 +48,7 @@ function Invoke-BoltInternal {
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo("$env:RUBY_DIR\bin\ruby.exe", "-S -- $env:RUBY_DIR\bin\bolt $BoltCommandLine")
         $startInfo.UseShellExecute = $false
         $startInfo.CreateNoWindow = $true
+        $startInfo.WorkingDirectory = Get-Location
         $startInfo.RedirectStandardError = $true
         $startInfo.RedirectStandardOutput = $true
         $bolt_process = New-Object System.Diagnostics.Process


### PR DESCRIPTION
Previous to this commit: Invoke-BoltInternal was using ProcessStartInfo
_without_ WorkingDirectory set. This means any bolt processes would
not be executing from the directory the user is in when attempting to
execute bolt cmdlets.

This commit adds a line to set workingdirectory to Get-Location


